### PR TITLE
content: add http category and HttpClientModule checklist item

### DIFF
--- a/content/http/.category
+++ b/content/http/.category
@@ -1,0 +1,4 @@
+---
+title: HTTP
+summary: This category summarizes best practices regarding HTTP interactions and modules.
+---

--- a/content/http/dont-reimport-httpclientmodule.md
+++ b/content/http/dont-reimport-httpclientmodule.md
@@ -1,0 +1,16 @@
+---
+title: don't re-import HttpClientModule
+---
+
+# Problem
+
+`HttpClientModule` is responsible for providing us with HTTP related functionality. One such functionality is the ability to specify interceptors that inspect and transform HTTP requests from your application to the server.
+When re-importing `HttpClientModule` in a lazy-loaded module or a dependency of a lazy-loaded module, existing HTTP interceptors will be overridden for that module.
+
+# Solution
+
+Import `HttpClientModule` only once in the root module.
+
+# Resources
+
+- [HTTP_INTERCEPTORS are reset when re-importing HttpClientModule](https://github.com/angular/angular/issues/20575)


### PR DESCRIPTION
As promised. This pull request will create a new category 'HTTP' containing a checklist item on why not to reimport HttpClientModule.
As per the contributing guidelines I've tried to keep it as short and concise as possible. 

I'll write a more in-depth blogpost about this later for those looking for more information.