### PR TITLE
content(rxjs): avoid memory leaks

### DIFF
--- a/content/rxjs/use-ngifas.md
+++ b/content/rxjs/use-ngifas.md
@@ -72,7 +72,7 @@ We can also make our Observable hot so that the Observable will no longer trigge
 
 This fixes our problem because it means it doesn't matter anymore if we have multiple subscriptions.
 
-To do this, we can use for example the `shareReplay` operator.
+To do this, we can use for example the `publishReplay` and `refCount` operators.
 
 ```ts
 @Component({
@@ -81,7 +81,8 @@ To do this, we can use for example the `shareReplay` operator.
 })
 export class SomeComponent implements OnInit, OnDestroy {
   sharedData$ = data$.pipe(
-    shareReplay(1)
+    publishReplay(1),
+    refCount()
   );
   ...
 }

--- a/content/rxjs/use-ngifas.md
+++ b/content/rxjs/use-ngifas.md
@@ -72,7 +72,7 @@ We can also make our Observable hot so that the Observable will no longer trigge
 
 This fixes our problem because it means it doesn't matter anymore if we have multiple subscriptions.
 
-To do this, we can use for example the `publishReplay` and `refCount` operators.
+To do this, we can use for example the `shareReplay` operator.
 
 ```ts
 @Component({
@@ -81,12 +81,13 @@ To do this, we can use for example the `publishReplay` and `refCount` operators.
 })
 export class SomeComponent implements OnInit, OnDestroy {
   sharedData$ = data$.pipe(
-    publishReplay(1),
-    refCount()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
   ...
 }
 ```
+
+> Note: we should specify `refCount: true` to prevent possible memory leaks.
 
 # Resources
 


### PR DESCRIPTION
Use `publishReplay` and `refCount` instead of `shareReplay` to avoid memory leaks.
See https://github.com/ReactiveX/rxjs/issues/3336